### PR TITLE
Remove the dch function for gbp-pull-upstream

### DIFF
--- a/.github/workflows/gbp-pull-upstream.yaml
+++ b/.github/workflows/gbp-pull-upstream.yaml
@@ -63,16 +63,13 @@ jobs:
           git checkout --track origin/pristine-tar
           git checkout --track origin/upstream/latest
           git checkout debian/master          
-      - name: Update Changelog and Rebase Patches
+      - name: Rebase Patches
         run: |
           cd project
           gbp pq import
           gbp pq export
           git add debian
           git commit -m "Rebase patches" || true
-          gbp dch
-          git add debian
-          git commit -m "Update changelog" || true
       - name: Import Upstream
         run: |
           cd project


### PR DESCRIPTION
Remove the unneeded dch step before the release.  gbp will update the changelog itself when it pulls the upstream release.