### PR TITLE
Debian latest

### DIFF
--- a/.github/workflows/gbp-build.yaml
+++ b/.github/workflows/gbp-build.yaml
@@ -9,7 +9,7 @@ on:
       branch:
         type: string
         description: Git branch to build
-        default: debian/master
+        default: debian/latest
       series:
         type: string
         description: Build series
@@ -23,7 +23,7 @@ on:
       branch:
         type: string
         description: Git branch to build
-        default: debian/master
+        default: debian/latest
       series:
         type: string
         description: Build series


### PR DESCRIPTION
Update the default branch in the build workflow to `debian/latest`

This is in line with the recent changes in salsa.