### PR TITLE
Add branch info to update matrix

### DIFF
--- a/.github/workflows/check-updates.yaml
+++ b/.github/workflows/check-updates.yaml
@@ -9,21 +9,36 @@ jobs:
     strategy:
       matrix:
         repo:
-          - git@salsa.debian.org:gnome-team/epiphany-browser.git
-          - git@salsa.debian.org:gnome-team/gnome-software.git
-          - git@salsa.debian.org:gnome-team/gedit.git
-          - git@salsa.debian.org:gnome-team/gedit-plugins.git
-            #- git@salsa.debian.org:gnome-team/glib.git
-          - git@salsa.debian.org:gnome-team/geary.git
-          - git@salsa.debian.org:gnome-team/gnome-calculator.git
-          - git@salsa.debian.org:gnome-team/gnome-system-monitor.git
-          - git@salsa.debian.org:gnome-team/orca.git
-          - git@salsa.debian.org:gnome-team/gnome-flashback.git
-          - git@salsa.debian.org:gnome-team/evince.git
-          - git@salsa.debian.org:gnome-team/gnome-boxes.git
-          - git@salsa.debian.org:gnome-team/gnome-remote-desktop.git
-          - git@salsa.debian.org:gnome-team/gnome-backgrounds.git
-          - git@salsa.debian.org:gnome-team/gnome-connections.git
+          - url: git@salsa.debian.org:gnome-team/epiphany-browser.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/gnome-software.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/gedit.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/gedit-plugins.git
+            branch: debian/latest
+            #- url: git@salsa.debian.org:gnome-team/glib.git
+            # branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/geary.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/gnome-calculator.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/gnome-system-monitor.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/orca.git
+            branch: debian/experimental
+          - url: git@salsa.debian.org:gnome-team/gnome-flashback.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/evince.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/gnome-boxes.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/gnome-remote-desktop.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/gnome-backgrounds.git
+            branch: debian/latest
+          - url: git@salsa.debian.org:gnome-team/gnome-connections.git
+            branch: debian/latest
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
@@ -55,4 +70,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ubuntu/deb-ci/actions/workflows/59636522/dispatches \
-            -d '{"ref":"main","inputs":{"repo":"${{ matrix.repo }}"}}'
+            -d '{"ref":"main","inputs":{"repo":"${{ matrix.repo.url }}","branch":"${{ matrix.repo.branch }}"}}'

--- a/.github/workflows/gbp-pull-upstream.yaml
+++ b/.github/workflows/gbp-pull-upstream.yaml
@@ -6,12 +6,20 @@ on:
         type: string
         description: Downstream repository to clone
         required: true
+      branch:
+        type: string
+        description: Branch for gbp to import into
+        default: debian/latest
   workflow_dispatch:
     inputs:
       repo:
         type: string
         description: Downstream repository to clone
         required: true
+      branch:
+        type: string
+        description: Branch for gbp to import into
+        default: debian/latest
 
 env:
   DEBEMAIL: ${{ secrets.LP_EMAIL }}
@@ -66,7 +74,7 @@ jobs:
           cd project
           git checkout --track origin/pristine-tar
           git checkout --track origin/upstream/latest
-          git checkout debian/latest
+          git checkout ${{ inputs.branch }}
       - name: Rebase Patches
         run: |
           cd project
@@ -83,7 +91,7 @@ jobs:
           cd project
           git push salsa.bot upstream/latest --force
           git push salsa.bot pristine-tar --force
-          git push salsa.bot debian/latest --force
+          git push salsa.bot ${{ inputs.branch }} --force
           git push salsa.bot --tags
       - name: Create Issue
         if: failure()
@@ -117,7 +125,7 @@ jobs:
     secrets: inherit
     with:
       repo: git@salsa.debian.org:gnome-team/${{ needs.gbp-pull-upstream.outputs.project-name }}.git
-      branch: debian/latest
+      branch: ${{ inputs.branch }}
       series: mantic
   mm-notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Provide branch information for each repo.  This allows repos that dont use `debian/latest` to be overridden (ie. orca)